### PR TITLE
chore: exclude warnings package from requirements.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.pyc
+venv

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ requests
 numpy
 beautifulsoup4
 lxml
-warnings
 gunicorn
 pycountry
 waitress


### PR DESCRIPTION
Excluding `warnings` package to fix #9 